### PR TITLE
Fix for AK5C side rails.

### DIFF
--- a/FA_Weapons_VKN/config.cpp
+++ b/FA_Weapons_VKN/config.cpp
@@ -614,7 +614,6 @@ class VKN_AK5C : FA_Base_Rifle_VKN
       {
         linkProxy = "\A3\data_f\proxies\weapon_slots\SIDE";
         displayName = "$STR_A3_PointerSlot0";
-        compatibleItems[] = {"acc_flashlight", "acc_pointer_IR"};
         iconScale = 0.1;
       };
       class UnderBarrelSlot : SlotInfo

--- a/VKN_Compatibility/config.cpp
+++ b/VKN_Compatibility/config.cpp
@@ -11,7 +11,8 @@ class CfgPatches {
 		requiredAddons[] =
     {
 		  "A3_Weapons_F",
-      "A3_Data_F"
+      "A3_Data_F",
+      "FA_Weapons_VKN"
     };
     weapons[] = {"VKN_AK5C", "VKN_MP5", "VKN_VSS"};
 	};
@@ -31,6 +32,10 @@ class asdg_OpticRail1913_short;
 class asdg_OpticRail1913_long;
 class asdg_MuzzleSlot_556;
 class asdg_MuzzleSlot_9MM_SMG;
+
+//RHS JR
+class rhs_western_rifle_laser_slot;
+class rhs_western_rifle_laser_slot_top;
 
 
 //Normal

--- a/VKN_Misc/config.cpp
+++ b/VKN_Misc/config.cpp
@@ -27,6 +27,7 @@ class CfgPatches {
             "A3_Map_Altis_Scenes",
             "A3_Map_VR_Scenes",
             "A3_Map_Malden_Scenes_F",
+            "FA_Weapons_VKN",
             "VKN_Functions"
         };
     };


### PR DESCRIPTION
* Fixes part of #18.
* Bipods were not touched due to lack of a rail in the underside of the AK5C's model.